### PR TITLE
Composite adapter

### DIFF
--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -107,6 +107,14 @@ Compositeadapter.prototype.completeTask = function(task, callback) {
   db.completeTask(task, callback);
 };
 
+Compositeadapter.prototype.disableTask = function(task, callback) {
+  var db = this._findDbById(task.id.db_id);
+  if(!db) {
+    callback(new Error('There is no database with id ' + task.id.db_id));
+  }
+  db.disableTask(task, callback);
+};
+
 /** Pick a db with round robin */
 Compositeadapter.prototype._pickDb = function() {
   this._round_robin_index = (this._round_robin_index + 1) % this._databases.length;

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -4,14 +4,14 @@ module.exports.initialize = initialize;
 
 function Compositeadapter(config, databases) {
   this._databases = databases;
-  this._rr_index = -1;
+  this._round_robin_index = -1;
 }
 
 function initialize(config, callback, config_helper) {
   config_helper = config_helper ? config_helper : require('../config/index');
 
-  if(!config.dbopt || !(config.dbopt instanceof Array)) {
-    callback(new Error('conf.dbopt should be an Array, can\'t initialize composite adapter'));
+  if(!checkConfSanity(config)) {
+    callback(new Error('conf.dbopt is not sane, can\'t initialize composite adapter'));
     return;
   }
 
@@ -32,11 +32,10 @@ Compositeadapter.prototype.saveTask = function(task, callback, failcounter) {
     return;
   }
 
-  var index = this._pickDbIndex();
-  var db_id = this._databases[index].db_id;
-  this._databases[index].saveTask(task, function(err, row_id) {
+  var db = this._pickDb();
+  db.saveTask(task, function(err, row_id) {
     if(err) {
-      logger.err(new Error('Unreachable database \''+ db_id +'\': ' + err.message));
+      logger.err(new Error('Unreachable database \''+ db.db_id +'\': ' + err.message));
       _this.saveTask(task, callback, ++failcounter);       // Call saveTask recursively until a working
       return;                                              // database is found.
     }
@@ -66,9 +65,9 @@ Compositeadapter.prototype.completeTask = function(task, callback) {
   db.completeTask(task, callback);
 };
 
-Compositeadapter.prototype._pickDbIndex = function() {
-  this._rr_index = (this._rr_index + 1) % this._databases.length;
-  return this._rr_index;
+Compositeadapter.prototype._pickDb = function() {
+  this._round_robin_index = (this._round_robin_index + 1) % this._databases.length;
+  return this._databases[this._round_robin_index];
 };
 
 Compositeadapter.prototype._findDbById = function(db_id) {
@@ -78,6 +77,12 @@ Compositeadapter.prototype._findDbById = function(db_id) {
   }
   return null;
 };
+
+function checkConfSanity(config) {
+  return (config.dbopt &&
+           (config.dbopt instanceof Array) &&
+           config.dbopt.length > 0);
+}
 
 function populateDatabasesArray(config, databases, config_helper) {
   config.dbopt.forEach(function(dbconf) {
@@ -89,3 +94,4 @@ function populateDatabasesArray(config, databases, config_helper) {
     });
   });
 }
+

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -1,0 +1,53 @@
+
+module.exports.initialize = initialize;
+
+function Compositeadapter(config, databases) {
+  this._databases = databases;
+}
+
+function initialize(config, callback, config_helper) {
+  config_helper = config_helper ? config_helper : require('../config/index');
+
+  if(!config.dbopt || !(config.dbopt instanceof Array)) {
+    callback(new Error('conf.dbopt should be an Array, can\'t initialize composite adapter'));
+    return;
+  }
+
+  var databases = new Array();
+  populateDbconnsArray(config, databases, config_helper);
+
+  var adapter = new Compositeadapter(config, databases);
+  callback(null, adapter);
+}
+
+Compositeadapter.prototype.saveTask = function(task, callback) {
+  this._pickDb().dbconn.saveTask(task, callback);
+};
+
+Compositeadapter.prototype.listenTask = function(callback) {
+};
+
+Compositeadapter.prototype.updateTask = function(task, callback) {
+};
+
+Compositeadapter.prototype.completeTask = function(task, callback) {
+};
+
+Compositeadapter.prototype._pickDb = function() {
+  var random = Math.random;
+  return this._databases[Math.floor(random()*this._databases.length)];
+}
+
+function populateDbconnsArray(config, databases, config_helper) {
+  config.dbopt.forEach(function(dbconf) {
+    config_helper.initializeDb(dbconf, function(err, augmented_conf) {
+      if(err) {
+        throw new Error('Could not initialize a db connection: ' + err.message);
+      }
+      databases.push({
+        db_id: dbconf.db_id,
+        dbconn: augmented_conf.dbconn
+      });
+    });
+  });
+}

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -16,7 +16,7 @@ function initialize(config, callback, config_helper) {
   }
 
   var databases = new Array();
-  populateDbconnsArray(config, databases, config_helper);
+  populateDatabasesArray(config, databases, config_helper);
 
   var adapter = new Compositeadapter(config, databases);
   callback(null, adapter);
@@ -79,7 +79,7 @@ Compositeadapter.prototype._findDbById = function(db_id) {
   return null;
 };
 
-function populateDbconnsArray(config, databases, config_helper) {
+function populateDatabasesArray(config, databases, config_helper) {
   config.dbopt.forEach(function(dbconf) {
     config_helper.initializeDb(dbconf, function(err, augmented_conf) {
       if(err) {

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -8,6 +8,7 @@ module.exports.initialize = initialize;
 
 function Compositeadapter(config, databases) {
   this._databases = databases;
+  this._rr_index = -1;
 }
 
 function initialize(config, callback, config_helper) {
@@ -59,8 +60,8 @@ Compositeadapter.prototype.completeTask = function(task, callback) {
 };
 
 Compositeadapter.prototype._pickDbIndex = function() {
-  var random = Math.random;
-  return Math.floor(random()*this._databases.length);
+  this._rr_index = (this._rr_index + 1)%this._databases.length
+  return this._rr_index;
 }
 
 function populateDbconnsArray(config, databases, config_helper) {

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -21,7 +21,7 @@ function Compositeadapter(config, databases) {
  */
 
 function initialize(config, callback, config_helper) {
-  config_helper = config_helper ? config_helper : require('../config/index');
+  config_helper = config_helper || require('../config/index');
 
   if(!checkConfSanity(config)) {
     callback(new Error('conf.dbopt is not sane, can\'t initialize composite adapter'));
@@ -55,6 +55,9 @@ Compositeadapter.prototype.saveTask = function(task, callback, failcounter) {
   }
 
   var db = this._pickDb();
+  if(!db.connected) 
+    return saveTask(task, callback, ++failcounter);
+
   db.saveTask(task, function(err, row_id) {
     if(err) {
       logger.err(new Error('Unreachable database \''+ db.db_id +'\': ' + err.message));
@@ -87,7 +90,7 @@ Compositeadapter.prototype.listenTask = function(callback) {
 Compositeadapter.prototype.updateTask = function(task, callback) {
   var db = this._findDbById(task.id.db_id);
   if(!db) {
-    callback(new Error('There is no database with id ' + task.id.db_id));
+    callback(new Error('There is no database available with id ' + task.id.db_id));
   }
   db.updateTask(task, callback);
 };
@@ -102,7 +105,7 @@ Compositeadapter.prototype.updateTask = function(task, callback) {
 Compositeadapter.prototype.completeTask = function(task, callback) {
   var db = this._findDbById(task.id.db_id);
   if(!db) {
-    callback(new Error('There is no database with id ' + task.id.db_id));
+    callback(new Error('There is no database available with id ' + task.id.db_id));
   }
   db.completeTask(task, callback);
 };
@@ -110,7 +113,7 @@ Compositeadapter.prototype.completeTask = function(task, callback) {
 Compositeadapter.prototype.disableTask = function(task, callback) {
   var db = this._findDbById(task.id.db_id);
   if(!db) {
-    callback(new Error('There is no database with id ' + task.id.db_id));
+    callback(new Error('There is no database available with id ' + task.id.db_id));
   }
   db.disableTask(task, callback);
 };
@@ -124,7 +127,8 @@ Compositeadapter.prototype._pickDb = function() {
 /** Find a db by its id */
 Compositeadapter.prototype._findDbById = function(db_id) {
   for(var i=0;i < this._databases.length;++i) {
-    if(this._databases[i].db_id === db_id)
+    if(this._databases[i].db_id === db_id &&
+        this._databases[i].connected)
       return this._databases[i];
   }
   return null;

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -7,6 +7,19 @@ function Compositeadapter(config, databases) {
   this._round_robin_index = -1;
 }
 
+/**
+ * A composite adapter that consists of multiple adapters.
+ * The adapters may be of a different type.
+ *
+ * `config.dbopt` should be an array containing JSON-objects
+ * that will be used to initialize the individual adapters. This function
+ * uses config/index.js's initializeDb-function to initialize the adapters.
+ *
+ * @param {Object} config - Configuration object as passed from config.js
+ * @param {Function} callback
+ * @param {Object} config_helper - A helper to use for initializing adapters (for testing)
+ */
+
 function initialize(config, callback, config_helper) {
   config_helper = config_helper ? config_helper : require('../config/index');
 
@@ -21,6 +34,15 @@ function initialize(config, callback, config_helper) {
   var adapter = new Compositeadapter(config, databases);
   callback(null, adapter);
 }
+
+/**
+ * Uses round robin to find a reachable database to which the
+ * task is saved.
+ *
+ * @param {Object} task - Task to save
+ * @param {Function} callback
+ * @param {number} failcounter - Used internally
+ */
 
 Compositeadapter.prototype.saveTask = function(task, callback, failcounter) {
   var _this = this;
@@ -43,11 +65,24 @@ Compositeadapter.prototype.saveTask = function(task, callback, failcounter) {
   });
 };
 
+/**
+ * Calls listenTask for all the initialized adapters.
+ *
+ * @param {Function} callback - Called when a task becomes available
+ */
+
 Compositeadapter.prototype.listenTask = function(callback) {
   this._databases.forEach(function(db) {
     db.listenTask(callback);
   });
 };
+
+/**
+ * Updates a task in the database specified by `task.id.db_id`.
+ *
+ * @param {Object} task
+ * @param {Function} callback
+ */
 
 Compositeadapter.prototype.updateTask = function(task, callback) {
   var db = this._findDbById(task.id.db_id);
@@ -57,6 +92,13 @@ Compositeadapter.prototype.updateTask = function(task, callback) {
   db.updateTask(task, callback);
 };
 
+/**
+ * Completes a task in the database specified by `task.id.db_id`.
+ *
+ * @param {Object} task
+ * @param {Function} callback
+ */
+
 Compositeadapter.prototype.completeTask = function(task, callback) {
   var db = this._findDbById(task.id.db_id);
   if(!db) {
@@ -65,11 +107,13 @@ Compositeadapter.prototype.completeTask = function(task, callback) {
   db.completeTask(task, callback);
 };
 
+/** Pick a db with round robin */
 Compositeadapter.prototype._pickDb = function() {
   this._round_robin_index = (this._round_robin_index + 1) % this._databases.length;
   return this._databases[this._round_robin_index];
 };
 
+/** Find a db by its id */
 Compositeadapter.prototype._findDbById = function(db_id) {
   for(var i=0;i < this._databases.length;++i) {
     if(this._databases[i].db_id === db_id)

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -2,10 +2,6 @@ var logger = require('../log');
 
 module.exports.initialize = initialize;
 
-
-// TODO: Save unreachable databases to an array and check with
-//       timeouts if they have come online??
-
 function Compositeadapter(config, databases) {
   this._databases = databases;
   this._rr_index = -1;
@@ -37,9 +33,10 @@ Compositeadapter.prototype.saveTask = function(task, callback, failcounter) {
   }
 
   var index = this._pickDbIndex();
-  this._databases[index].dbconn.saveTask(task, function(err, row_id) {
+  var db_id = this._databases[index].db_id;
+  this._databases[index].saveTask(task, function(err, row_id) {
     if(err) {
-      logger.err(new Error('Disabling unreachable database: ' + err.message));
+      logger.err(new Error('Unreachable database \''+ db_id +'\': ' + err.message));
       _this.saveTask(task, callback, ++failcounter);       // Call saveTask recursively until a working
       return;                                              // database is found.
     }
@@ -49,20 +46,38 @@ Compositeadapter.prototype.saveTask = function(task, callback, failcounter) {
 
 Compositeadapter.prototype.listenTask = function(callback) {
   this._databases.forEach(function(db) {
-    db.dbconn.listenTask(callback);
+    db.listenTask(callback);
   });
 };
 
 Compositeadapter.prototype.updateTask = function(task, callback) {
+  var db = this._findDbById(task.id.db_id);
+  if(!db) {
+    callback(new Error('There is no database with id ' + task.id.db_id));
+  }
+  db.updateTask(task, callback);
 };
 
 Compositeadapter.prototype.completeTask = function(task, callback) {
+  var db = this._findDbById(task.id.db_id);
+  if(!db) {
+    callback(new Error('There is no database with id ' + task.id.db_id));
+  }
+  db.completeTask(task, callback);
 };
 
 Compositeadapter.prototype._pickDbIndex = function() {
-  this._rr_index = (this._rr_index + 1)%this._databases.length
+  this._rr_index = (this._rr_index + 1) % this._databases.length;
   return this._rr_index;
-}
+};
+
+Compositeadapter.prototype._findDbById = function(db_id) {
+  for(var i=0;i < this._databases.length;++i) {
+    if(this._databases[i].db_id === db_id)
+      return this._databases[i];
+  }
+  return null;
+};
 
 function populateDbconnsArray(config, databases, config_helper) {
   config.dbopt.forEach(function(dbconf) {
@@ -70,10 +85,7 @@ function populateDbconnsArray(config, databases, config_helper) {
       if(err) {
         throw new Error('Could not initialize a db connection: ' + err.message);
       }
-      databases.push({
-        db_id: dbconf.db_id,
-        dbconn: augmented_conf.dbconn
-      });
+      databases.push(augmented_conf.dbconn);
     });
   });
 }

--- a/lib/adapters/composite.js
+++ b/lib/adapters/composite.js
@@ -1,5 +1,10 @@
+var logger = require('../log');
 
 module.exports.initialize = initialize;
+
+
+// TODO: Save unreachable databases to an array and check with
+//       timeouts if they have come online??
 
 function Compositeadapter(config, databases) {
   this._databases = databases;
@@ -20,11 +25,31 @@ function initialize(config, callback, config_helper) {
   callback(null, adapter);
 }
 
-Compositeadapter.prototype.saveTask = function(task, callback) {
-  this._pickDb().dbconn.saveTask(task, callback);
+Compositeadapter.prototype.saveTask = function(task, callback, failcounter) {
+  var _this = this;
+  failcounter = isNaN(failcounter) ? 0 : failcounter;
+
+  // this prevents the function from being called recursively indefinitely :P
+  if(failcounter >= this._databases.length) {
+    callback(new Error('No databases available (maybe they are all down?)'));
+    return;
+  }
+
+  var index = this._pickDbIndex();
+  this._databases[index].dbconn.saveTask(task, function(err, row_id) {
+    if(err) {
+      logger.err(new Error('Disabling unreachable database: ' + err.message));
+      _this.saveTask(task, callback, ++failcounter);       // Call saveTask recursively until a working
+      return;                                              // database is found.
+    }
+    callback(null, row_id); 
+  });
 };
 
 Compositeadapter.prototype.listenTask = function(callback) {
+  this._databases.forEach(function(db) {
+    db.dbconn.listenTask(callback);
+  });
 };
 
 Compositeadapter.prototype.updateTask = function(task, callback) {
@@ -33,9 +58,9 @@ Compositeadapter.prototype.updateTask = function(task, callback) {
 Compositeadapter.prototype.completeTask = function(task, callback) {
 };
 
-Compositeadapter.prototype._pickDb = function() {
+Compositeadapter.prototype._pickDbIndex = function() {
   var random = Math.random;
-  return this._databases[Math.floor(random()*this._databases.length)];
+  return Math.floor(random()*this._databases.length);
 }
 
 function populateDbconnsArray(config, databases, config_helper) {

--- a/test/unit/composite-adapter-test.js
+++ b/test/unit/composite-adapter-test.js
@@ -168,6 +168,29 @@ suite('composite-adapter', function() {
       .calledWith(task, callback);
     });
   });
+  suite('disableTask()', function() {
+    var dbconn;
+    setup(function() {
+      initSandbox();
+      composite.initialize(
+        config,
+        function(e,dbconn_local) { dbconn = dbconn_local },
+        config_helper);
+    });
+
+    teardown(function() {
+      sandbox.restore();
+    });
+    
+    test('calls disableTask() of correct adapter', function() {
+      var callback = sandbox.spy();
+      var task = {id:{db_id:2}};
+      dbconn.completeTask(task, callback);
+      expect(dbconn._databases[2].disableTask).to.have.been.calledOnce;
+      expect(dbconn._databases[2].disableTask).to.have.been
+      .calledWith(task, callback);
+    });
+  });
   suite('_findDbById()', function() {
     var dbconn;
     setup(function() {

--- a/test/unit/composite-adapter-test.js
+++ b/test/unit/composite-adapter-test.js
@@ -28,6 +28,12 @@ suite('composite-adapter', function() {
       expect(callback).to.have.been.calledOnce;
       expect(callback.args[0][0]).to.not.be.null;
     });
+    test('should call callback with error if dbopt is empty', function() {
+      var fake_config = {dbopt:[]};
+      composite.initialize(fake_config, callback);
+      expect(callback).to.have.been.calledOnce;
+      expect(callback.args[0][0]).to.not.be.null;
+    });
     test('should call callback with no error if everything goes smoothly', function() {
       composite.initialize(config, callback, config_helper);
       expect(callback).to.have.been.calledOnce;

--- a/test/unit/composite-adapter-test.js
+++ b/test/unit/composite-adapter-test.js
@@ -185,7 +185,7 @@ suite('composite-adapter', function() {
     test('calls disableTask() of correct adapter', function() {
       var callback = sandbox.spy();
       var task = {id:{db_id:2}};
-      dbconn.completeTask(task, callback);
+      dbconn.disableTask(task, callback);
       expect(dbconn._databases[2].disableTask).to.have.been.calledOnce;
       expect(dbconn._databases[2].disableTask).to.have.been
       .calledWith(task, callback);
@@ -217,6 +217,7 @@ suite('composite-adapter', function() {
       adapter.listenTask = sandbox.spy();
       adapter.updateTask = sandbox.spy();
       adapter.completeTask = sandbox.spy();
+      adapter.disableTask = sandbox.spy();
       adapters[i] = adapter;
       var aug_conf = {dbconn: adapter}
       config_helper.initializeDb.onCall(i).callsArgWith(1, null, aug_conf);

--- a/test/unit/composite-adapter-test.js
+++ b/test/unit/composite-adapter-test.js
@@ -96,6 +96,14 @@ suite('composite-adapter', function() {
         expect(savetask_callback).to.have.been.calledOnce;
         expect(savetask_callback.args[0][0]).to.be.an.instanceof(Error);
       });
+      test('throws if no dbs are connected', function()  {
+        dbconn._databases.forEach(function(db) {
+          db.connected = false;
+        });
+        expect(function() {
+          dbconn.saveTask({}, savetask_callback)
+        }).to.throw(Error);
+      });
     });
   });
 
@@ -218,6 +226,7 @@ suite('composite-adapter', function() {
       adapter.updateTask = sandbox.spy();
       adapter.completeTask = sandbox.spy();
       adapter.disableTask = sandbox.spy();
+      adapter.connected = true;
       adapters[i] = adapter;
       var aug_conf = {dbconn: adapter}
       config_helper.initializeDb.onCall(i).callsArgWith(1, null, aug_conf);

--- a/test/unit/composite-adapter-test.js
+++ b/test/unit/composite-adapter-test.js
@@ -116,6 +116,52 @@ suite('composite-adapter', function() {
       });
     });
   });
+  suite('updateTask()', function() {
+    var dbconn;
+    setup(function() {
+      initSandbox();
+      composite.initialize(
+        config,
+        function(e,dbconn_local) { dbconn = dbconn_local },
+        config_helper);
+    });
+
+    teardown(function() {
+      sandbox.restore();
+    });
+    
+    test('calls updateTask() of correct adapter', function() {
+      var callback = sandbox.spy();
+      var task = {id:{db_id:2}};
+      dbconn.updateTask(task, callback);
+      expect(dbconn._databases[2].updateTask).to.have.been.calledOnce;
+      expect(dbconn._databases[2].updateTask).to.have.been
+      .calledWith(task, callback);
+    });
+  });
+  suite('completeTask()', function() {
+    var dbconn;
+    setup(function() {
+      initSandbox();
+      composite.initialize(
+        config,
+        function(e,dbconn_local) { dbconn = dbconn_local },
+        config_helper);
+    });
+
+    teardown(function() {
+      sandbox.restore();
+    });
+    
+    test('calls completeTask() of correct adapter', function() {
+      var callback = sandbox.spy();
+      var task = {id:{db_id:2}};
+      dbconn.completeTask(task, callback);
+      expect(dbconn._databases[2].completeTask).to.have.been.calledOnce;
+      expect(dbconn._databases[2].completeTask).to.have.been
+      .calledWith(task, callback);
+    });
+  });
   suite('_findDbById()', function() {
     var dbconn;
     setup(function() {
@@ -140,6 +186,8 @@ suite('composite-adapter', function() {
       var adapter = {db_id: i};
       adapter.saveTask = sandbox.spy();
       adapter.listenTask = sandbox.spy();
+      adapter.updateTask = sandbox.spy();
+      adapter.completeTask = sandbox.spy();
       adapters[i] = adapter;
       var aug_conf = {dbconn: adapter}
       config_helper.initializeDb.onCall(i).callsArgWith(1, null, aug_conf);

--- a/test/unit/composite-adapter-test.js
+++ b/test/unit/composite-adapter-test.js
@@ -1,0 +1,82 @@
+var composite = require('../../lib/adapters/composite')
+  , chai = require('chai')
+  , sinon = require('sinon')
+  , sinonChai = require('sinon-chai')
+  , expect = chai.expect;
+
+chai.use(sinonChai);
+
+suite('composite-adapter', function() {
+  var sandbox = sinon.sandbox.create()
+    , callback
+    , config = {}
+    , bad_config = {}
+    , config_helper = {}
+    , good_config = [{
+        db: 'sqlite',
+        db_id: 'sqlite://sqlite.db'
+      },{
+        db: 'sqlite',
+        db_id: 'sqlite://sqlite2.db'
+      }];
+
+  setup(function() {
+    callback = sandbox.spy();
+
+    config.dbopt = good_config;
+
+    augmented_conf = config;
+    augmented_conf.dbconn = {};
+    augmented_conf.dbmodule = {};
+
+    augmented_conf.dbconn.saveTask = sandbox.spy();
+    config_helper.initializeDb = sinon.stub();
+    config_helper.initializeDb.callsArgWith(1, null, augmented_conf);
+
+  });
+  teardown(function() {
+    sandbox.restore();
+  });
+  suite('initialize()', function() {
+    test('should call callback with error if dbopt is of invalid type', function() {
+      config.dbopt = bad_config;
+      composite.initialize(config, callback);
+      expect(callback).to.have.been.calledOnce;
+      expect(callback.args[0][0]).to.not.be.null;
+    });
+    test('should call callback with no error if everything goes smoothly', function() {
+      composite.initialize(config, callback, config_helper);
+      expect(callback).to.have.been.calledOnce;
+      expect(callback.args[0][0]).to.be.null;
+    });
+    test('populates _databases array correctly', function() {
+      composite.initialize(config, callback, config_helper);
+      var _databases = callback.args[0][1]._databases;
+      expect(_databases[0]).to.have.property('db_id');
+      expect(_databases[1]).to.have.property('db_id');
+      expect(_databases[0]).to.have.property('dbconn');
+      expect(_databases[1]).to.have.property('dbconn');
+    });
+  });
+  suite('saveTask()', function() {
+    var dbconn;
+    setup(function() {
+      composite.initialize(
+        config,
+        function(e,dbconn_local) { dbconn = dbconn_local },
+        config_helper);
+    });
+
+    teardown(function() {
+      sandbox.restore();
+    });
+    test('saves a task to a random database', function() {
+      var task = {};
+      var savetask_callback = sandbox.spy();
+      dbconn.saveTask(task, savetask_callback);
+      expect(augmented_conf.dbconn.saveTask).to.have.been.calledOnce;
+      expect(augmented_conf.dbconn.saveTask).to.have.been.calledWith(task, savetask_callback);
+    });
+  });
+});
+


### PR DESCRIPTION
Supports all the features described in the db adapter api. saveTask uses always an adapter that is connected, and it uses round robin to distribute calls to adapters. listenTask will try to register the callback to all the adapters. updateTask, completeTask and disableTask will call callback with error if the db adapter specified by db_id is unreachable. Feel free to merge.
