### PR TITLE
Working vagrant setup

### DIFF
--- a/.provision/apt.sh
+++ b/.provision/apt.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/99translations
 apt-get update
-apt-get install --yes --no-install-recommends gearman npm nodejs nodejs-legacy sqlite3
+apt-get install --yes --no-install-recommends gearman npm nodejs-legacy sqlite \
+  git

--- a/.provision/apt.sh
+++ b/.provision/apt.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
-NODE=/usr/bin/node
 echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/99translations
 apt-get update
-apt-get install --yes --no-install-recommends gearman npm nodejs-legacy sqlite \
-  git
+apt-get install --yes --no-install-recommends gearman npm nodejs nodejs-legacy sqlite3

--- a/.provision/apt.sh
+++ b/.provision/apt.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+NODE=/usr/bin/node
 echo 'Acquire::Languages "none";' > /etc/apt/apt.conf.d/99translations
 apt-get update
-apt-get install --yes --no-install-recommends gearman npm nodejs nodejs-legacy sqlite3
+apt-get install --yes --no-install-recommends gearman npm nodejs-legacy sqlite \
+  git

--- a/.provision/make.sh
+++ b/.provision/make.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
-cd /vagrant || exit 1
-make clean
+#!/bin/bash
+GEARSLOTH_PATH=$HOME/gearsloth
+mkdir -p $GEARSLOTH_PATH
+git clone /vagrant $GEARSLOTH_PATH
+cd $GEARSLOTH_PATH
 make build

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ MOCHA := ./node_modules/.bin/mocha
 MOCHA_ALT := ./node_modules/.bin/_mocha
 ISTANBUL := ./node_modules/.bin/istanbul
 
+GEARMAN_COFFEE := node_modules/gearman-coffee/lib-js
+
 # run local gearman server and gearsloth worker
 define start-local
 	FAIL=; GM_PID=; GS_PID=;\
@@ -15,20 +17,23 @@ define start-local
 	[ -z $$FAIL ]
 endef
 
+.PHONY: build
+build: $(GEARMAN_COFFEE)
+
 .PHONY: test
-test: node_modules
+test: $(GEARMAN_COFFEE)
 	$(MOCHA) $(MOCHA_PARAMS) test/
 
 .PHONY: unit-test
-unit-test: node_modules
+unit-test: $(GEARMAN_COFFEE)
 	$(MOCHA) $(MOCHA_PARAMS) test/unit
 
 .PHONY: e2e-test
-e2e-test: node_modules
+e2e-test: $(GEARMAN_COFFEE)
 	$(MOCHA) $(MOCHA_PARAMS) test/e2e
 
 .PHONY: coverage
-coverage: node_modules
+coverage: $(GEARMAN_COFFEE)
 	-$(ISTANBUL) cover --report cobertura $(MOCHA_ALT) -- $(MOCHA_PARAMS) test/
 
 .PHONY: html-coverage
@@ -36,12 +41,20 @@ html-coverage: coverage
 	-$(ISTANBUL) report html
 
 .PHONY: log-delayed
-log-delayed: node_modules
+log-delayed: $(GEARMAN_COFFEE)
 	-@$(call start-local, ./examples/bin/log-delayed)
+
+$(GEARMAN_COFFEE): node_modules/gearman-coffee/node_modules/coffee-script
+	cd node_modules/gearman-coffee; make
+	touch $@
+
+node_modules/gearman-coffee/node_modules/coffee-script: node_modules
+	cd node_modules/gearman-coffee; npm install
+	touch $@
 
 node_modules: package.json
 	npm install
-	touch node_modules
+	touch $@
 
 .PHONY: build
 build: node_modules

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,8 +7,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   ### Machine settings
   #
   config.vm.hostname = "sloth-host"
-  config.vm.box      = "sloth-2014-05-18"
-  config.vm.box_url  = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
+  config.vm.box      = "sloth-2014-06-06"
+  config.vm.box_url  = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
   ### Provisioning
   #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,14 +7,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   ### Machine settings
   #
   config.vm.hostname = "sloth-host"
-  config.vm.box      = "sloth-2014-06-06"
-  config.vm.box_url  = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box      = "sloth-2014-05-18"
+  config.vm.box_url  = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
 
   ### Provisioning
   #
   config.vm.provision :shell, path: ".provision/stdintty.sh"
   config.vm.provision :shell, path: ".provision/apt.sh"
-  config.vm.provision :shell, path: ".provision/make.sh", privileged: false
+  config.vm.provision :shell, path: ".provision/make.sh"
 
   ### Virtalbox configuration
   #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
   config.vm.provision :shell, path: ".provision/stdintty.sh"
   config.vm.provision :shell, path: ".provision/apt.sh"
-  config.vm.provision :shell, path: ".provision/make.sh"
+  config.vm.provision :shell, path: ".provision/make.sh", privileged: false
 
   ### Virtalbox configuration
   #

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,14 +7,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   ### Machine settings
   #
   config.vm.hostname = "sloth-host"
-  config.vm.box      = "sloth-2014-05-18"
-  config.vm.box_url  = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-i386-vagrant-disk1.box"
+  config.vm.box      = "sloth-2014-06-06"
+  config.vm.box_url  = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
   ### Provisioning
   #
   config.vm.provision :shell, path: ".provision/stdintty.sh"
   config.vm.provision :shell, path: ".provision/apt.sh"
-  config.vm.provision :shell, path: ".provision/make.sh"
+  config.vm.provision :shell, path: ".provision/make.sh", privileged: false
 
   ### Virtalbox configuration
   #

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "homepage": "https://github.com/meetings/gearman-delayed-task",
   "dependencies": {
-    "gearman-coffee": "^2.0.0",
+    "gearman-coffee": "git://github.com/meetings/gearman-coffee.git",
     "underscore": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
- Use modified gearman-coffee that uses reconnect-net with fewer dependencies
- Update vagrant provisioning scripts so that gearsloth development folder is not shared with the VM

The previous vagrant setup used a shared gearsloth development folder. This caused problems because the platform dependent `node_modules` folder was also shared. This patch clones the development folder inside the VM and installs dependencies independently of the development environment.
