### PR TITLE
Multiserver events and logging

### DIFF
--- a/lib/controllers/retry.js
+++ b/lib/controllers/retry.js
@@ -21,10 +21,10 @@ function Retry(conf) {
   this._tasks = {};
   this._client = new client.MultiserverClient(conf.servers);
   this._worker = new worker.MultiserverWorker(conf.servers, 'retryController',
-        function (payload, worker) {
-          var task = JSON.parse(payload.toString());
-          that.workHandler(task, worker);
-        });
+      function (payload, worker) {
+        var task = JSON.parse(payload.toString());
+        that.workHandler(task, worker);
+      });
 
   // start worker only after client has connected
   this._client.on('connect', function() {
@@ -32,7 +32,7 @@ function Retry(conf) {
       that._emitConnected();
   });
   this._client.on('disconnect', function() {
-    if(!that._worker.connected)
+    if(that._worker.connected)
       that._emitDisconnected();
   });
   this._worker.on('connect', function() {
@@ -40,7 +40,7 @@ function Retry(conf) {
       that._emitConnected();
   });
   this._worker.on('disconnect', function() {
-    if(!that._client.connected)
+    if(that._client.connected)
       that._emitDisconnected();
   });
 }

--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -27,6 +27,9 @@ Daemon.prototype.add = function(path, conf) {
   component.on('connect', function() {
     that.setConnected(id, true);
   });
+  component.on('disconnect', function() {
+    that.setConnected(id, false);
+  });
 };
 
 Daemon.prototype.allConnected = function() {
@@ -40,9 +43,9 @@ Daemon.prototype.setConnected = function(id, connected) {
   this._components[id].connected = connected;
   var next = this.allConnected();
   if (prev && !next)
-    log.info('gearslothd:', 'partially disconnected');
+    log.info('gearslothd:', 'disconnected');
   else if (!prev && next)
-    log.info('gearslothd:', 'fully connected');
+    log.info('gearslothd:', 'connected');
 };
 
 module.exports = new Daemon();

--- a/lib/gearman/index.js
+++ b/lib/gearman/index.js
@@ -1,0 +1,2 @@
+exports.Worker = require('./multiserver-worker').Worker;
+exports.Client = require('./multiserver-client').Client;

--- a/lib/gearman/multiserver-client.js
+++ b/lib/gearman/multiserver-client.js
@@ -1,5 +1,8 @@
-var events = require('events');
 var util = require('util');
+var events = require('events');
+var gearman = require('gearman-coffee');
+var Multiserver = require('./multiserver');
+var log = require('../log');
 
 /**
  * A gearman client that supports multiple servers.
@@ -10,39 +13,31 @@ var util = require('util');
  * Servers are provided in an array of json-objects, possible fields are:
  *  `.host`:    a string that identifies a gearman job server host
  *  `.port`:    an integer that identifies a geaerman job server port
- *  `.debug`:   a boolean that tells whether debug mode should be used
+ *  `._debug`:   a boolean that tells whether debug mode should be used
  *
  * @param {[Object]} servers
  * @return {Object}
  */
 
 function MultiserverClient(servers, Client) {
-  events.EventEmitter.call(this);
-  Client = Client || require("gearman-coffee").Client;
-  this.connected = false;
+  Client = Client || gearman.Client;
+  Multiserver.call(this, servers, function(server) {
+    return new Client(server);
+  });
+  this.component_name = 'client';
   this._rr_index = -1;    // round robin index
-  this._connected_count = 0;
-
-  if (!servers) {
-    this._clients = [ new Client() ];
-  } else {
-    this._clients = servers.map(function(server) {
-      return new Client(server);
-    });
-  }
-
-  this._registerListeners();
-
 }
 
-util.inherits(MultiserverClient, events.EventEmitter);
+util.inherits(MultiserverClient, Multiserver);
 
 /**
  * Selects a connected client and submits a job to it.
  */
 
 MultiserverClient.prototype.submitJob = function(func_name, payload) {
-  return this._pickConnectedClient().submitJob(func_name, payload);
+  var index = this._pickConnectedClient();
+  this._debug('submitting job to server', this._serverString(index));
+  return this._connections[index].submitJob(func_name, payload);
 };
 
 /**
@@ -52,12 +47,16 @@ MultiserverClient.prototype.submitJob = function(func_name, payload) {
  */
 
 MultiserverClient.prototype.submitJobBg = function(func_name, payload) {
-  var client = this._pickConnectedClient();
-  var job = new events.EventEmitter();
+  var index = this._pickConnectedClient();
+  this._debug('submitting background job to', this._serverString(index));
 
+  var that = this;
+  var client = this._connections[index];
+  var job = new events.EventEmitter();
   client.queue.push(job);
   client.sendCommand('SUBMIT_JOB_BG', func_name, false, payload);
   job.on('created', function(handle) {
+    that._debug('background job created with handle', handle);
     // delete job immediately because WORK_COMPLETE is not expected
     delete client.jobs[handle];
   });
@@ -65,48 +64,18 @@ MultiserverClient.prototype.submitJobBg = function(func_name, payload) {
   return job;
 };
 
-/** Disconnect all clients */
-MultiserverClient.prototype.disconnect = function() {
-  this._clients.forEach(function(client) {
-    client.disconnect();
-  });
-};
-
 /** Returns a connected client from the clients array */
 MultiserverClient.prototype._pickConnectedClient = function() {
+  if (!this.connected) {
+    this._debug('all servers disconnected, buffering to any server');
+  }
   var counter = 0;
   do {
-    this._rr_index = (this._rr_index + 1) % this._clients.length;
-  } while ((!this._clients[this._rr_index].connected) &&
-            ++counter < this._clients.length &&
+    this._rr_index = (this._rr_index + 1) % this._connections.length;
+  } while ((!this._connections[this._rr_index].connected) &&
+            ++counter < this._connections.length &&
             this.connected);
-
-  return this._clients[this._rr_index];
-};
-
-MultiserverClient.prototype._registerListeners = function() {
-  var that = this;
-  this._emitConnect = function() {
-    ++that._connected_count;
-    that.connected = true;
-    that.emit('connect');
-  };
-
-  this._emitDisconnect = function() {
-    that._connected_count = 0;
-    that.connected = false;
-    that.emit('disconnect');
-  };
-
-  this._clients.forEach(function(client) {
-    client.reconnecter.on('connect', that._emitConnect);
-    // emit disconnect if all clients have discoed
-    client.reconnecter.on('disconnect', function() {
-      if(--that._connected_count === 0) {
-        that._emitDisconnect();       
-      }
-    });
-  });
+  return this._rr_index;
 };
 
 module.exports.MultiserverClient = MultiserverClient;

--- a/lib/gearman/multiserver-worker.js
+++ b/lib/gearman/multiserver-worker.js
@@ -1,5 +1,8 @@
 var events = require('events');
 var util = require('util');
+var gearman = require('gearman-coffee');
+var Multiserver = require('./multiserver');
+var log = require('../log');
 
 /**
  * A gearman worker that supports multiple servers.
@@ -19,49 +22,17 @@ var util = require('util');
  */
 
 function MultiserverWorker(servers, func_name, callback, Worker) {
-  events.EventEmitter.call(this);
-  Worker = Worker || require('gearman-coffee').Worker;
-  this.connected = false;
-  this._connected_count = 0;
-
+  Worker = Worker || gearman.Worker;
   var that = this;
-  this._emitConnect = function() {
-    ++that._connected_count;
-    that.connected = true;
-    that.emit('connect');
-  };
-
-  this._emitDisconnect = function() {
-    that._connected_count = 0;
-    that.connected = false;
-    that.emit('disconnect');
-  };
-
-  if (!servers) {
-    this._workers = [ new Worker(func_name, callback) ];
-  } else {
-    this._workers = servers.map(function(server) {
-      return new Worker(func_name, callback, server);
-    });
-  }
-
-  this._workers.forEach(function(worker) {
-    worker.on('connect', that._emitConnect);
-    worker.reconnecter.on('disconnect', function() {
-      if(--that._connected_count === 0) {
-        that._emitDisconnect();
-      }
-    });
+  Multiserver.call(this, servers, function(server, index) {
+    return new Worker(func_name, function(payload, worker) {
+      that._debug('received job from', that._serverString(index));
+      return callback(payload, worker);
+    }, server);
   });
+  this.component_name = 'worker';
 }
 
-util.inherits(MultiserverWorker, events.EventEmitter);
-
-/** Disconnect all workers */
-MultiserverWorker.prototype.disconnect = function() {
-  this._workers.forEach(function(worker) {
-    worker.disconnect();
-  });
-};
+util.inherits(MultiserverWorker, Multiserver);
 
 module.exports.MultiserverWorker = MultiserverWorker;

--- a/lib/gearman/multiserver.js
+++ b/lib/gearman/multiserver.js
@@ -1,0 +1,86 @@
+var events = require('events');
+var crypto = require('crypto');
+var util = require('util');
+var log = require('../log');
+
+function Multiserver(servers, create_connection) {
+  events.EventEmitter.call(this);
+  this.connected = false;
+  this.component_name = 'multiserver';
+  this._id = this._generateId();
+  this._connected_count = 0;
+  this._servers = servers || [ { host: 'localhost', port: 4730 } ];
+  this._connections = this._servers.map(create_connection);
+  this._registerListeners();
+}
+
+util.inherits(Multiserver, events.EventEmitter);
+
+Multiserver.prototype._generateId = function() {
+  return crypto.pseudoRandomBytes(4).toString('hex');
+};
+
+/** Disconnect all servers */
+Multiserver.prototype.disconnect = function() {
+  this._debug('disconnecting all servers');
+  this._connections.forEach(function(connection) {
+    connection.disconnect();
+  });
+};
+
+Multiserver.prototype._emitConnect = function() {
+  this._debug('connected');
+  this.connected = true;
+  this.emit('connect');
+};
+
+Multiserver.prototype._emitDisconnect = function() {
+  this._debug('all servers disconnected');
+  this.connected = false;
+  this.emit('disconnect');
+};
+
+Multiserver.prototype._registerListeners = function() {
+  var that = this;
+
+  this._connections.forEach(function(connection, index) {
+    // emit connect when the first client connects
+    connection.reconnecter.on('connect', function() {
+      that._debug(that._serverString(index), 'connected');
+      if (++that._connected_count === 1) {
+        that._emitConnect();
+      }
+    });
+    connection.reconnecter.on('reconnect', function(n, delay) {
+      that._debug(that._serverString(index), 'reconnecting (' +
+          n + ' retries, ' + delay + ' ms delay)');
+    });
+    // emit disconnect if all clients have discoed
+    connection.reconnecter.on('disconnect', function(err) {
+      if (err) {
+        that._debug(that._serverString(index), 'disconnected:', err.message);
+      } else {
+        // live connection disconnected
+        that._debug(that._serverString(index), 'disconnected');
+        if (--that._connected_count === 0) {
+          that._emitDisconnect();
+        }
+      }
+    });
+  });
+};
+
+// for logging/debugging
+
+Multiserver.prototype._serverString = function(index) {
+  var server = this._servers[index];
+  return (server.host || 'localhost') + ':' + (server.port || '4730');
+};
+
+Multiserver.prototype._debug = function() {
+  log.debug
+      .bind(undefined, this.component_name + '(' + this._id + '):')
+      .apply(undefined, arguments);
+};
+
+module.exports = Multiserver;

--- a/test/lib/spawn.js
+++ b/test/lib/spawn.js
@@ -13,7 +13,7 @@ var gearslothd = exports.gearslothd = function(conf, done) {
   var conf_arg = '--conf=' + JSON.stringify(conf);
   var gearslothd = child_process.spawn('./bin/gearslothd', [ conf_arg ]);
   //gearslothd.stdout.pipe(process.stdout);
-  readUntilMatch(gearslothd.stdout, /gearslothd: fully connected/, done);
+  readUntilMatch(gearslothd.stdout, /gearslothd: connected/, done);
   return gearslothd;
 }
 

--- a/test/unit/multiserver-client-test.js
+++ b/test/unit/multiserver-client-test.js
@@ -72,10 +72,10 @@ suite("multiserver-client", function() {
         ClientStub);
 
       m.connected = true;
-      m._clients.forEach(function(client) {
+      m._connections.forEach(function(client) {
         client.submitJob = sandbox.spy();
       });
-      m._clients[sampleServers.length-1].connected = true;
+      m._connections[sampleServers.length-1].connected = true;
     });
     teardown(function() {
       sandbox.restore();
@@ -83,11 +83,11 @@ suite("multiserver-client", function() {
 
     test("submits to that server", function() {
       m.submitJob('mita', 'hessu');
-      expect(m._clients[0].submitJob)
+      expect(m._connections[0].submitJob)
       .to.not.have.been.called;
-      expect(m._clients[1].submitJob)
+      expect(m._connections[1].submitJob)
       .to.not.have.been.called;
-      expect(m._clients[sampleServers.length-1].submitJob)
+      expect(m._connections[sampleServers.length-1].submitJob)
       .to.have.been.calledOnce;
     });
   });
@@ -100,7 +100,7 @@ suite("multiserver-client", function() {
         sampleServers,
         ClientStub);
 
-      m._clients.forEach(function(client) {
+      m._connections.forEach(function(client) {
         client.submitJob = sandbox.spy();
       });
 
@@ -111,12 +111,12 @@ suite("multiserver-client", function() {
 
     test("submits to a client anyway", function(done) {
       m.submitJob('mita', 'hessu');
-      var called_clients = 0;
-      m._clients.forEach(function(client) {
-        if(client.submitJob.calledOnce) called_clients++;
+      var called_connections = 0;
+      m._connections.forEach(function(client) {
+        if(client.submitJob.calledOnce) called_connections++;
       });
-      if(called_clients === 1) done();
-      else if(called_clients > 1) done(new Error('Job was sent to more than one client'));
+      if(called_connections === 1) done();
+      else if(called_connections > 1) done(new Error('Job was sent to more than one client'));
       else done(new Error('Job was not sent'));
     });
 
@@ -125,10 +125,10 @@ suite("multiserver-client", function() {
       m.submitJob('mita', 'hessu');
       m.submitJob('mita', 'hessu');
 
-      var called_clients = 0;
+      var called_connections = 0;
       var stop = false;
-      m._clients.forEach(function(client) {
-        if(client.submitJob.calledOnce) called_clients++;
+      m._connections.forEach(function(client) {
+        if(client.submitJob.calledOnce) called_connections++;
         if(client.submitJob.calledTwice) {
           done(new Error('Job was sent to same client'));
           stop = true;
@@ -137,8 +137,8 @@ suite("multiserver-client", function() {
       });
       if(stop) return;
 
-      if(called_clients === 2) done();
-      else if(called_clients > 2) done(new Error('Job was sent to too many clients'));
+      if(called_connections === 2) done();
+      else if(called_connections > 2) done(new Error('Job was sent to too many clients'));
       else done(new Error('Job was not sent'));
       });
   });
@@ -170,7 +170,7 @@ suite("multiserver-client", function() {
         ClientStub);
       client = new EventEmitter();
 
-      m._clients.forEach(function(client) {
+      m._connections.forEach(function(client) {
         client.disconnect = sandbox.spy();
       });
     });
@@ -181,16 +181,16 @@ suite("multiserver-client", function() {
 
     test("should call disconnect for all clients", function() {
       m.disconnect();
-      m._clients.forEach(function(client) {
+      m._connections.forEach(function(client) {
         expect(client.disconnect).to.have.been.calledOnce;
       });
     });
     test("should emit disconnect event", function(done) {
         this.timeout(500);
         m.on('disconnect', done);
-        m._connected_count = m._clients.length;
+        m._connected_count = m._connections.length;
         m.disconnect();
-        m._clients.forEach(function(client) {
+        m._connections.forEach(function(client) {
           client.reconnecter.emit('disconnect');
         });
     });

--- a/test/unit/multiserver-worker-test.js
+++ b/test/unit/multiserver-worker-test.js
@@ -40,9 +40,9 @@ suite("multiserver-worker", function() {
     test("should spawn as many worker instances", function() {
       expect(exports.Worker).to.be.calledTwice;
       expect(exports.Worker).to.be
-      .calledWith('sample', dummy_func, sampleServers[0]);
+      .calledWith('sample', sinon.match.any, sampleServers[0]);
       expect(exports.Worker).to.be
-      .calledWith('sample', dummy_func, sampleServers[1]);
+      .calledWith('sample', sinon.match.any, sampleServers[1]);
     });
   });
   suite("when given no servers", function() {
@@ -81,16 +81,16 @@ suite("multiserver-worker", function() {
 
     test("should call disconnect for all workers", function() {
       m.disconnect();
-      m._workers.forEach(function(worker) {
+      m._connections.forEach(function(worker) {
         expect(worker.disconnect).to.have.been.calledOnce;
       });
     });
     test("should emit disconnect event", function(done) {
       this.timeout(500);
       m.on('disconnect', done);
-      m._connected_count = m._workers.length;
+      m._connected_count = m._connections.length;
       m.disconnect();
-      m._workers.forEach(function(worker) {
+      m._connections.forEach(function(worker) {
         worker.reconnecter.emit('disconnect');
       });
     });


### PR DESCRIPTION
- Refactor common parts of multiserver worker and and client to a 'base class'
- Add debug messages to multiserver
- Change connect/disconnect event emitting logic
  - `connect` is emitted when changing state from 'all servers disconnected' to 'single server connected'
  - `disconnect` is emitted in the opposite case
- Change gearslothd on connect info message
- Enable require('./lib/gearman').Worker pattern
