### PR TITLE
Create vagrant virtualbox machine according to host capabilities

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 # Vagrantfile for Gearsloth test environment
 # vi: set sw=2 ts=2 sts=2 ft=ruby :
+require_relative 'virt/vagrant/host.rb'
 
 VAGRANTFILE_API_VERSION = "2"
 
@@ -21,7 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
   config.vm.provider :virtualbox do |virtualbox|
     virtualbox.name   = "sloth-test-env"
-    virtualbox.memory = "1024"
-    virtualbox.cpus = "2"
+    virtualbox.memory = (Host.total_memory || 2048) / 2
+    virtualbox.cpus   = Host.processor_count || 2
   end
 end

--- a/virt/vagrant/host.rb
+++ b/virt/vagrant/host.rb
@@ -1,0 +1,27 @@
+module Host
+  def self.processor_count
+    case RbConfig::CONFIG['host_os']
+    when /darwin9/
+      `hwprefs cpu_count`.to_i
+    when /darwin/
+      ((`which hwprefs` != '') ? `hwprefs thread_count` : `sysctl -n hw.ncpu`).to_i
+    when /linux/
+      `cat /proc/cpuinfo | grep processor | wc -l`.to_i
+    when /freebsd/
+      `sysctl -n hw.ncpu`.to_i
+    when /mswin|mingw/
+      require 'win32ole'
+      wmi = WIN32OLE.connect("winmgmts://")
+      cpu = wmi.ExecQuery("select NumberOfCores from Win32_Processor")
+      # TODO count hyper-threaded in this
+      cpu.to_enum.first.NumberOfCores
+    end
+  end
+  def self.total_memory
+    case RbConfig::CONFIG['host_os']
+    when /linux/
+      `cat /proc/meminfo | grep MemTotal | awk '{print $2}'`.to_i / 1024
+    # TODO windows and mac support
+    end
+  end
+end


### PR DESCRIPTION
Virtual machine total memory and cpu count are set to match host
capabilites or to sane default values, if capabilites can't be detected.
