### PR TITLE
Limit recursion depth to avoid huge object dumps

### DIFF
--- a/lib/daemon/index.js
+++ b/lib/daemon/index.js
@@ -8,7 +8,7 @@ function Daemon(conf) {
 Daemon.prototype.initialize = function(conf) {
   if (conf.verbose) log.setVerbose(conf.verbose);
   log.debug('gearslothd', 'Config parsed:\n',
-      util.inspect(conf, { depth: null }));
+      util.inspect(conf, { depth: 3 }));
 
   if (conf.injector)    this.add('./injector',        conf);
   if (conf.runner)      this.add('./runner',          conf);


### PR DESCRIPTION
Pretty printing with infinite recursion depth leads to massive log flood. This should avoid it.
